### PR TITLE
Removed the storage of issues in the GithubProject

### DIFF
--- a/src/Rs/Issues/Github/GithubProject.php
+++ b/src/Rs/Issues/Github/GithubProject.php
@@ -20,11 +20,6 @@ class GithubProject implements Project
     private $client;
 
     /**
-     * @var array
-     */
-    private $issues = array();
-
-    /**
      * @param array  $data
      * @param Client $client
      */
@@ -71,7 +66,7 @@ class GithubProject implements Project
             $newIssues[] = new GithubIssue($issue);
         }
 
-        return $this->issues = $newIssues;
+        return $newIssues;
     }
 
     /**


### PR DESCRIPTION
This property is only used in a write context. It is never read again. So its only goal is to increase the refcount to forbid PHP to garbage collect the issues after you are done with them.
